### PR TITLE
Add explicit API mode to kotlin compiler 

### DIFF
--- a/updater/build.gradle.kts
+++ b/updater/build.gradle.kts
@@ -34,6 +34,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += "-Xexplicit-api=strict"
     }
 
     publishing {

--- a/updater/src/main/java/com/farsitel/bazaar/updater/BazaarUpdater.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/BazaarUpdater.kt
@@ -13,11 +13,11 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import java.lang.ref.WeakReference
 
-object BazaarUpdater {
+public object BazaarUpdater {
 
     private var connection: WeakReference<UpdateServiceConnection>? = null
 
-    fun getLastUpdateState(
+    public fun getLastUpdateState(
         context: Context,
         scope: CoroutineScope = retrieveScope(context),
         onResult: (UpdateResult) -> Unit
@@ -33,7 +33,7 @@ object BazaarUpdater {
         }
     }
 
-    fun updateApplication(context: Context) {
+    public fun updateApplication(context: Context) {
         val intent = if (verifyBazaarIsInstalled(context).not()) {
             Intent(Intent.ACTION_VIEW, "$BAZAAR_WEB_APP_DETAIL${context.packageName}".toUri())
         } else {

--- a/updater/src/main/java/com/farsitel/bazaar/updater/Exceptions.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/Exceptions.kt
@@ -1,10 +1,10 @@
 package com.farsitel.bazaar.updater
 
-class UnknownException(
+public class UnknownException(
     override val message: String = "There is some problems, maybe the sign or package" +
             " Name is not same as the application published on Bazaar or maybe Bazaar client is not sync"
 ) : RuntimeException()
 
-class BazaarIsNotInstalledException(
+public class BazaarIsNotInstalledException(
     override val message: String = "Bazaar is not installed in your device!"
 ) : RuntimeException()

--- a/updater/src/main/java/com/farsitel/bazaar/updater/UpdateResult.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/UpdateResult.kt
@@ -1,22 +1,22 @@
 package com.farsitel.bazaar.updater
 
-sealed class UpdateResult {
-    data class NeedUpdate(val targetVersion: Long) : UpdateResult()
-    object AlreadyUpdated : UpdateResult()
-    data class Error(val throwable: Throwable) : UpdateResult()
+public sealed class UpdateResult {
+    public data class NeedUpdate(val targetVersion: Long) : UpdateResult()
+    public object AlreadyUpdated : UpdateResult()
+    public data class Error(val throwable: Throwable) : UpdateResult()
 }
 
-inline fun UpdateResult.doOnUpdateNeeded(call: (Long) -> Unit): UpdateResult {
+public inline fun UpdateResult.doOnUpdateNeeded(call: (Long) -> Unit): UpdateResult {
     if (this is UpdateResult.NeedUpdate) call(targetVersion)
     return this
 }
 
-inline fun UpdateResult.doOnAlreadyUpdated(call: () -> Unit): UpdateResult {
+public inline fun UpdateResult.doOnAlreadyUpdated(call: () -> Unit): UpdateResult {
     if (this is UpdateResult.AlreadyUpdated) call()
     return this
 }
 
-inline fun UpdateResult.doOnError(call: (Throwable) -> Unit): UpdateResult {
+public inline fun UpdateResult.doOnError(call: (Throwable) -> Unit): UpdateResult {
     if (this is UpdateResult.Error) call(throwable)
     return this
 }


### PR DESCRIPTION
In this Merge Request, I have made two significant changes to improve the flexibility and usability of our codebase.

### Explicit API mode for the compiler: 
I have added an explicit API mode to the compiler. This mode requires all public API to be explicitly marked as such, which helps to maintain a clean and clear public API surface. It prevents accidental exposure of internal implementation details and encourages developers to think more carefully about API design.

### Public BazaarUpdater methods:
I have made the methods in the BazaarUpdater class public. This change allows these methods to be accessed and used in other parts of the application or even by other applications, increasing the reusability of our code. It provides more flexibility for developers who want to use our updater functionality in their own code.

These changes are part of our ongoing efforts to improve the quality of our code and make it more developer-friendly. We believe that these changes will make our codebase more robust, easier to use, and maintain.