### PR TITLE
Fix: Fix DeadObjectException inside AutoUpdateServiceConnection

### DIFF
--- a/updater/build.gradle.kts
+++ b/updater/build.gradle.kts
@@ -57,7 +57,7 @@ publishing {
         create("release", MavenPublication::class) {
             groupId = "com.farsitel.bazaar"
             artifactId = "updater"
-            version = "1.0.0-beta1"
+            version = "1.1.1-alpha1"
 
             afterEvaluate {
                 from(components["release"])

--- a/updater/src/main/java/com/farsitel/bazaar/updater/AutoUpdateServiceConnection.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/AutoUpdateServiceConnection.kt
@@ -2,6 +2,7 @@ package com.farsitel.bazaar.updater
 
 import android.content.ComponentName
 import android.content.ServiceConnection
+import android.os.DeadObjectException
 import android.os.IBinder
 import com.farsitel.bazaar.IAutoUpdateCheckService
 import kotlinx.coroutines.CoroutineScope
@@ -42,5 +43,6 @@ internal class AutoUpdateServiceConnection(
     }
 
     override fun onServiceDisconnected(d: ComponentName?) {
+        onError(DeadObjectException())
     }
 }

--- a/updater/src/main/java/com/farsitel/bazaar/updater/AutoUpdateServiceConnection.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/AutoUpdateServiceConnection.kt
@@ -2,7 +2,6 @@ package com.farsitel.bazaar.updater
 
 import android.content.ComponentName
 import android.content.ServiceConnection
-import android.os.DeadObjectException
 import android.os.IBinder
 import com.farsitel.bazaar.IAutoUpdateCheckService
 import kotlinx.coroutines.CoroutineScope
@@ -42,7 +41,7 @@ internal class AutoUpdateServiceConnection(
         }
     }
 
-    override fun onServiceDisconnected(d: ComponentName?) {
-        onError(DeadObjectException())
+    override fun onServiceDisconnected(componentName: ComponentName?) {
+        onError(ServiceDisconnectionException(componentName))
     }
 }

--- a/updater/src/main/java/com/farsitel/bazaar/updater/AutoUpdateServiceConnection.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/AutoUpdateServiceConnection.kt
@@ -20,22 +20,27 @@ internal class AutoUpdateServiceConnection(
         try {
             val service = IAutoUpdateCheckService.Stub.asInterface(boundService)
             scope.launch(Dispatchers.IO) {
-                val isAutoUpdateEnabled = if (bazaarVersionCode >= BAZAAR_CODE_AUTO_UPDATE_SUPPORTED) {
-                    service?.isAutoUpdateEnabled(packageName)
-                } else {
-                    null
-                }
-                if (isAutoUpdateEnabled != null) {
-                    onResult(isAutoUpdateEnabled)
-                } else {
-                    onError(BazaarIsNotUpdate())
+                try {
+                    val isAutoUpdateEnabled =
+                        if (bazaarVersionCode >= BAZAAR_CODE_AUTO_UPDATE_SUPPORTED) {
+                            service?.isAutoUpdateEnabled(packageName)
+                        } else {
+                            null
+                        }
+                    if (isAutoUpdateEnabled != null) {
+                        onResult(isAutoUpdateEnabled)
+                    } else {
+                        onError(BazaarIsNotUpdate())
+                    }
+                } catch (throwable: Throwable) {
+                    onError(throwable)
                 }
             }
-        } catch (t: Throwable) {
-            onError(t)
+        } catch (throwable: Throwable) {
+            onError(throwable)
         }
     }
 
-    override fun onServiceDisconnected(p0: ComponentName?) {
+    override fun onServiceDisconnected(d: ComponentName?) {
     }
 }

--- a/updater/src/main/java/com/farsitel/bazaar/updater/Exceptions.kt
+++ b/updater/src/main/java/com/farsitel/bazaar/updater/Exceptions.kt
@@ -1,5 +1,7 @@
 package com.farsitel.bazaar.updater
 
+import android.content.ComponentName
+
 public class UnknownException(
     override val message: String = "There is some problems, maybe the sign or package" +
             " Name is not same as the application published on Bazaar or maybe Bazaar client is not sync"
@@ -12,4 +14,9 @@ public class BazaarIsNotUpdate(
 
 public class BazaarIsNotInstalledException(
     override val message: String = "Bazaar is not installed in your device!"
+) : RuntimeException()
+
+public class ServiceDisconnectionException(
+    public val componentName: ComponentName?,
+    override val message: String = "Service $componentName is disconnected."
 ) : RuntimeException()


### PR DESCRIPTION
This PR tries to resolve the `DeadObjectException` crash on some devices
The issue may come across two reasons:
1. That remote process (in this case, the Bazaar app / update service) crashed, was killed, or disconnected right before or during your call.
2. The Binder reference (boundService) became invalid — hence DeadObjectException.

So the issue could be  calling `service.isAutoUpdateEnabled()` inside a coroutine on `Dispatchers.IO`, possibly seconds after `onServiceConnected()` returns.

That’s fine in principle, but if:
- The Bazaar process dies or is killed (e.g., low memory),
- Or your Activity/Service unbinds the connection,
- Or system reclaims the binder after a timeout,

the binder proxy becomes invalid → DeadObjectException.